### PR TITLE
Fix shrunken SVG images in editor content

### DIFF
--- a/assets/scss/styles/05-editor/_content.scss
+++ b/assets/scss/styles/05-editor/_content.scss
@@ -81,6 +81,11 @@
     height: auto;
 }
 
+// stylelint-disable-next-line selector-no-qualifying-type
+.editor figure img[src$=".svg"] {
+    width: 100%;
+}
+
 .editor figcaption {
     @include typography.style(small-caps);
 


### PR DESCRIPTION
## Před:

<img width="1160" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/130069731-6f7e59b3-b7f4-489d-9019-a579289bcbe6.png">

## Po:

<img width="1061" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/130069777-94dc3596-b857-4ef2-b5de-06e660a71bfa.png">
