### PR TITLE
Introduce `bottom-ad` advertising slot with data dynamically populated from Ghost admin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
     "browser": true
   },
   "globals": {
-    "gtag": false
+    "gtag": false,
+    "snippetsData": false
   },
   "parserOptions": {
     "ecmaVersion": 10,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -94,11 +94,21 @@ if (typeof gtag !== 'undefined') {
   });
 }
 
-// Replace snippets with actual content
+// Replace snippet placeholders with actual content defined in `<template>`.
+//
+// Example placeholder HTML:
+//
+// <div data-snippet="newsletter-signup"></div>
+//
+// Example template HTML:
+//
+// <template id="snippet__newsletter-signup__template">
+//     {{> "snippets/newsletter-signup"}}
+// </template>
 document.querySelectorAll('[data-snippet]').forEach((element) => {
   const snippetName = element.getAttribute('data-snippet');
   const snippet = document
-    .getElementById(`snippet_${snippetName}_template`)
+    .getElementById(`snippet__${snippetName}__template`)
     .content
     .cloneNode(true);
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -114,3 +114,41 @@ document.querySelectorAll('[data-snippet]').forEach((element) => {
 
   element.appendChild(snippet);
 });
+
+// Populate snippets with data from Ghost admin. All texts support HTML.
+//
+// Example data (inject into `<head>`):
+//
+// const snippetsData = {
+//   'bottom-ad': {
+//     ctaLabel: 'Dynamic CTA label',
+//     ctaUrl: 'https://www.example.com',
+//     text: 'Dynamic <strong>text</strong>',
+//     title: 'Dynamic title',
+//   },
+// };
+//
+// Example snippet HTML:
+//
+// <div data-populate="bottom-ad">
+//     <h2 id="bottom-ad__title"></h2>
+//     <p id="bottom-ad__text"></p>
+//     <a id="bottom-ad__cta"></a>
+// </div>
+document.querySelectorAll('[data-populate]').forEach((element) => {
+  const snippetName = element.getAttribute('data-populate');
+
+  if (typeof snippetsData === 'undefined') {
+    element.toggleAttribute('hidden');
+
+    // eslint-disable-next-line no-console -- Input data is managed in admin, warning is useful.
+    console.warn(`Warning: No data found for snippet "${snippetName}"! The snippet is now hidden.`);
+  } else if (snippetsData[snippetName]) {
+    const dataToPopulate = snippetsData[snippetName];
+
+    document.getElementById(`${snippetName}__title`).innerHTML = dataToPopulate.title;
+    document.getElementById(`${snippetName}__text`).innerHTML = dataToPopulate.text;
+    document.getElementById(`${snippetName}__cta`).innerHTML = dataToPopulate.ctaLabel;
+    document.getElementById(`${snippetName}__cta`).setAttribute('href', dataToPopulate.ctaUrl);
+  }
+});

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -31,6 +31,7 @@
 @use "styles/04-objects/content-block";
 @use "styles/04-objects/grid";
 @use "styles/04-objects/input-group";
+@use "styles/04-objects/media";
 @use "styles/04-objects/post-feed";
 @use "styles/04-objects/post-row";
 @use "styles/04-objects/section";

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -6,7 +6,6 @@
 // 1. Generic
 // Ground-zero styles.
 @use "styles/01-generic/box-sizing";
-@use "styles/01-generic/ie11";
 @use "styles/01-generic/print";
 @use "styles/01-generic/reset";
 @use "styles/01-generic/selection";

--- a/assets/scss/styles/01-generic/_ie11.scss
+++ b/assets/scss/styles/01-generic/_ie11.scss
@@ -1,7 +1,0 @@
-figure,
-footer,
-header,
-main,
-section {
-    display: block;
-}

--- a/assets/scss/styles/02-themes/_site.scss
+++ b/assets/scss/styles/02-themes/_site.scss
@@ -28,8 +28,9 @@
     --post-card-text-color: inherit;
     --primary-background-color: #{map.get(colors.$brand, green-darker)};
     --alternate-background-color: #{map.get(colors.$grays, gray-lightest)};
-    --dark-background-color: #{map.get(colors.$grays, gray-darker)};
+    --dark-background-color: #{map.get(colors.$grays, gray-darkest)};
     --footer-text-color: inherit;
+    --text-inverse-color: #{colors.$white};
     --text-muted-color: #{map.get(colors.$grays, gray-dark)};
     --ruler-color: #{map.get(colors.$grays, gray-lightest)};
 }
@@ -57,8 +58,9 @@
         --post-card-text-color: inherit;
         --primary-background-color: #{map.get(colors.$brand, green-darkest)};
         --alternate-background-color: #{map.get(colors.$grays, gray-darkest)};
-        --dark-background-color: #{map.get(colors.$grays, gray-darkest)};
+        --dark-background-color: #{color.adjust(map.get(colors.$grays, gray-darkest), $lightness: - 8%)};
         --footer-text-color: #{map.get(colors.$grays, gray)};
+        --text-inverse-color: #{map.get(colors.$grays, gray-light)};
         --text-muted-color: #{map.get(colors.$grays, gray-dark)};
         --ruler-color: #{color.adjust(map.get(colors.$grays, gray-dark), $alpha: - 0.8)};
     }

--- a/assets/scss/styles/04-objects/_media.scss
+++ b/assets/scss/styles/04-objects/_media.scss
@@ -1,0 +1,6 @@
+@use "../../settings/grid";
+
+.media {
+    display: flex;
+    gap: grid.$gap;
+}

--- a/assets/scss/styles/05-components/_author-card.scss
+++ b/assets/scss/styles/05-components/_author-card.scss
@@ -1,18 +1,9 @@
 @use "sass:map";
 @use "../../../../node_modules/modularscale-sass/stylesheets/modularscale";
-@use "../../settings/grid";
 @use "../../settings/typography" as typography-settings;
 @use "../../tools/typography";
 
 .author-card {
-    display: flex;
-}
-
-.author-card__media {
-    margin-right: grid.$gap;
-}
-
-.author-card__content {
     line-height: map.get(typography-settings.$line-height-values, dense);
 }
 

--- a/assets/scss/styles/08-utilities/_color.scss
+++ b/assets/scss/styles/08-utilities/_color.scss
@@ -1,7 +1,5 @@
-@use "../../settings/colors";
-
-.color-white {
-    color: colors.$white;
+.color-inverse {
+    color: var(--text-inverse-color);
 }
 
 .color-muted {

--- a/author.hbs
+++ b/author.hbs
@@ -16,10 +16,10 @@
 
                     <h1 class="article__title spacing-bottom">{{name}}</h1>
 
-                    <div class="author-card">
+                    <div class="media">
 
                         {{#if profile_image}}
-                            <div class="author-card__media">
+                            <div>
                                 <div class="avatar">
                                     <img
                                         src="{{img_url profile_image size="avatar_medium_2x"}}"
@@ -32,7 +32,7 @@
                         {{/if}}
 
                         {{#if bio}}
-                            <div class="author-card__content">
+                            <div class="author-card">
                                 <div class="author-card__bio">
                                     <p class="author-card__text spacing-bottom-small js-nbsp js-external-links">
                                         {{bio}}

--- a/author.hbs
+++ b/author.hbs
@@ -5,7 +5,14 @@
         <section class="section section--only-top print-padding-none">
             <div class="container">
 
-                <div class="article">
+                <div
+                    class="
+                        article
+                        {{#has slug="adam-kudrna"}}
+                            spacing-bottom
+                        {{/has}}
+                    "
+                >
 
                     <div class="article__meta">
                         <span class="spacing-right-1">
@@ -113,8 +120,30 @@
                     </div>
                 </div>
 
+                {{#has slug="adam-kudrna"}}
+                    <a
+                        href="https://www.adamkudrna.cz/konzultace"
+                        class="button button--primary spacing-bottom-small spacing-right-1"
+                        data-track="Navigate"
+                        data-category="Personal website"
+                        data-label="Author's page – primary CTA"
+                    >
+                        Objednat konzultaci
+                    </a>
+                    <a
+                        href="https://www.adamkudrna.cz/sluzby"
+                        class="button button--secondary spacing-bottom-small"
+                        data-track="Navigate"
+                        data-category="Personal website"
+                        data-label="Author's page – secondary CTA"
+                    >
+                        Prohlédnout všechny služby
+                    </a>
+                {{/has}}
+
             </div>
         </section>
+
         <section class="section">
             <div class="container">
 
@@ -135,6 +164,11 @@
 
             </div>
         </section>
+
+        {{#has slug="adam-kudrna"}}
+            {{> "bottom-ad"}}
+        {{/has}}
+
     </main>
 {{/author}}
 

--- a/custom-authors.hbs
+++ b/custom-authors.hbs
@@ -55,19 +55,17 @@
                                     {{/if}}
 
                                     <div class="author-card">
-                                        <div class="author-card__content">
-                                            <h3 class="author-card__name">
-                                                <span class="spacing-right-1">
-                                                    {{name}}
-                                                </span>
-                                                {{> "staff-label"}}
-                                            </h3>
-                                            {{#if bio}}
-                                                <p class="author-card__bio js-nbsp">
-                                                    {{bio}}
-                                                </p>
-                                            {{/if}}
-                                        </div>
+                                        <h3 class="author-card__name">
+                                            <span class="spacing-right-1">
+                                                {{name}}
+                                            </span>
+                                            {{> "staff-label"}}
+                                        </h3>
+                                        {{#if bio}}
+                                            <p class="author-card__bio js-nbsp">
+                                                {{bio}}
+                                            </p>
+                                        {{/if}}
                                     </div>
 
                                 </div>

--- a/custom-glossary.hbs
+++ b/custom-glossary.hbs
@@ -42,6 +42,11 @@
             </div>
 
         </article>
+
+        {{^has tag="#no-bottom-ad"}}
+            {{> "bottom-ad"}}
+        {{/has}}
+
     {{/post}}
 
     {{#get "posts"

--- a/partials/bottom-ad.hbs
+++ b/partials/bottom-ad.hbs
@@ -1,0 +1,29 @@
+<section class="section background-dark color-inverse print-hidden" data-populate="bottom-ad">
+    <div class="container container--narrow">
+
+        <h2 id="bottom-ad__title"></h2>
+        <div class="media spacing-bottom">
+            <div>
+                <div class="avatar">
+                    <img
+                        src="/content/images/size/w300/2020/10/profil_2016_1000x1000.jpg"
+                        loading="lazy"
+                        class="avatar__image"
+                        alt="Adam Kudrna"
+                    />
+                </div>
+            </div>
+            <p id="bottom-ad__text"></p>
+        </div>
+        <div class="text-center">
+            <a
+                id="bottom-ad__cta"
+                class="button button--primary"
+                data-track="navigate"
+                data-category="Personal website"
+                data-label="Bottom ad"
+            ></a>
+        </div>
+
+    </div>
+</section>

--- a/partials/byline-multiple.hbs
+++ b/partials/byline-multiple.hbs
@@ -1,3 +1,5 @@
+{{! DEAD CODE, THE TEMPLATE IS NOT ACTUALLY INVOKED ANYWHERE (YET). }}
+
 <section class="post-full-authors">
 
     <div class="post-full-authors-content">

--- a/partials/byline-single.hbs
+++ b/partials/byline-single.hbs
@@ -1,9 +1,9 @@
 {{#primary_author}}
 
-    <section class="author-card">
+    <section class="media">
 
         {{#if profile_image}}
-            <div class="author-card__media">
+            <div>
                 <a href="{{url}}" class="avatar avatar--link">
                     <img
                         src="{{img_url profile_image size="avatar_medium_2x"}}"
@@ -15,7 +15,7 @@
             </div>
         {{/if}}
 
-        <div class="author-card__content">
+        <div class="author-card">
 
             <h3 class="author-card__name">{{name}}</h3>
 

--- a/partials/glossary-group.hbs
+++ b/partials/glossary-group.hbs
@@ -1,7 +1,7 @@
-<section id="{{slug}}" aria-labelledby="h_{{slug}}">
+<section id="{{slug}}" aria-labelledby="h__{{slug}}">
 
     <h2
-        id="h_{{slug}}"
+        id="h__{{slug}}"
         class="text-headline-3 text-small-caps spacing-bottom-small"
     >
         {{name}}

--- a/partials/members/email-box.hbs
+++ b/partials/members/email-box.hbs
@@ -1,10 +1,10 @@
 <div class="input-group spacing-bottom-small">
-    <label for="{{id_prefix}}_email" class="visually-hidden">
+    <label for="{{id_prefix}}__email" class="visually-hidden">
         E-mail
     </label>
     <input
         type="email"
-        id="{{id_prefix}}_email"
+        id="{{id_prefix}}__email"
         class="text-field"
         placeholder="Zadejte svůj e-mail"
         size="25"

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -69,8 +69,8 @@
                 {{#foreach authors}}
                     <li {{^if @last}}class="spacing-bottom-small"{{/if}}>
 
-                        <div class="author-card">
-                            <div class="author-card__media">
+                        <div class="media">
+                            <div>
                                 {{#if profile_image}}
                                     <a href="{{url}}" class="avatar avatar--small avatar--link">
                                         <img
@@ -88,7 +88,7 @@
                                     </a>
                                 {{/if}}
                             </div>
-                            <div class="author-card__content">
+                            <div class="author-card">
                                 <div class="author-card__name">
                                     <a href="{{url}}" class="post-card__link link-unstyled">
                                         {{name}}

--- a/post.hbs
+++ b/post.hbs
@@ -123,7 +123,7 @@
 {{/contentFor}}
 
 {{#contentFor "snippets"}}
-    <template id="snippet_newsletter-signup_template">
+    <template id="snippet__newsletter-signup__template">
         {{> "snippets/newsletter-signup"}}
     </template>
 {{/contentFor}}

--- a/post.hbs
+++ b/post.hbs
@@ -97,6 +97,11 @@
             </div>
 
         </article>
+
+        {{^has tag="#no-bottom-ad"}}
+            {{> "bottom-ad"}}
+        {{/has}}
+
     {{/post}}
 
     {{#get "posts"

--- a/tag.hbs
+++ b/tag.hbs
@@ -3,14 +3,14 @@
 <main class="site__content background-alternate">
     <section
         class="section section--only-top print-padding-none"
-        aria-labelledby="h_header"
+        aria-labelledby="h__header"
     >
         <div class="container">
 
             {{#tag}}
                 <div class="article">
                     <div class="article__meta">Téma</div>
-                    <h1 id="h_header" class="article__title">{{name}}</h1>
+                    <h1 id="h__header" class="article__title">{{name}}</h1>
 
                     {{#if description}}
                         <p class="article__summary spacing-bottom-none js-nbsp">
@@ -36,11 +36,11 @@
             <section
                 id="slovnik"
                 class="section section--only-top"
-                aria-labelledby="h_slovnik"
+                aria-labelledby="h__slovnik"
             >
                 <div class="container">
 
-                    <h2 id="h_slovnik" class="spacing-bottom-small">Hesla ve slovníku</h2>
+                    <h2 id="h__slovnik" class="spacing-bottom-small">Hesla ve slovníku</h2>
 
                     <ul class="list-unstyled list-inline spacing-bottom-none">
                         {{#foreach glossary_items visibility="public"}}
@@ -63,7 +63,7 @@
     <section
         id="clanky"
         class="section"
-        aria-labelledby="h_clanky"
+        aria-labelledby="h__clanky"
     >
         <div class="container container--dense">
 
@@ -71,7 +71,7 @@
                 Hide the headline as we cannot be sure if there are some posts or not.
                 (It's visually redundant anyway.)
             }}
-            <h2 id="h_clanky" class="visually-hidden">Články</h2>
+            <h2 id="h__clanky" class="visually-hidden">Články</h2>
 
             <div class="post-feed">
                 {{#foreach posts visibility="public"}}


### PR DESCRIPTION
The slot can be disabled on post and glossary term details by adding internal tag `#no-bottom-ad`.

<img width="1915" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/153753999-5554adc9-8126-47b5-b59b-3ef17c52c7c9.png">
<img width="1914" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/153754046-8c2c7faa-f762-4eda-972a-4f09e0221060.png">

<img width="1090" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/153753922-835ee80b-37aa-455c-8da0-cf060ad0dd61.png">
<img width="1089" alt="obrazek" src="https://user-images.githubusercontent.com/5614085/153754087-400a58dd-0312-4367-98a7-df93db4d21e5.png">
