### PR TITLE
Introduce semi-obscured cover variant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ your machine.
    directory. Optionally clone the theme to a place of your choice and create
    a symlink in the said destination. Either way you should end up with this
    structure:
-   `<YOUR_GHOST_INSTALLATION>/content/frontend-garden-ghost-theme`.
+   `<YOUR_GHOST_INSTALLATION>/content/themes/frontend-garden-ghost-theme`.
 
 2. In the theme root run:
 

--- a/assets/scss/styles/06-components/_article.scss
+++ b/assets/scss/styles/06-components/_article.scss
@@ -39,3 +39,9 @@
     max-width: 42rem;
     margin-left: -0.15em; // 2.
 }
+
+.article--cover .article__title,
+.article--cover .article__summary {
+    width: clamp(24rem, 55vw, 50rem);
+    max-width: 100%;
+}

--- a/assets/scss/styles/06-components/_cover.scss
+++ b/assets/scss/styles/06-components/_cover.scss
@@ -108,6 +108,13 @@
     }
 }
 
+.cover--object--medium {
+    $overlay-color: color.adjust(colors.$black, $alpha: -0.75);
+
+    --gradient-from: #{$overlay-color};
+    --gradient-to: #{color.adjust($overlay-color, $alpha: -1)};
+}
+
 .cover--object--dark {
     $overlay-color: color.adjust(colors.$black, $alpha: -0.333);
 

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -10,6 +10,10 @@
             cover--object
             cover--object--light
         {{/has}}
+        {{#has tag="#cover-object-medium"}}
+            cover--object
+            cover--object--medium
+        {{/has}}
         {{#has tag="#cover-object-dark"}}
             cover--object
             cover--object--dark

--- a/post.hbs
+++ b/post.hbs
@@ -3,7 +3,7 @@
 <main class="site__content">
 
     {{#post}}
-        <article class="article">
+        <article class="article {{#has tag="#cover"}}article--cover{{/has}}">
 
             <header
                 class="
@@ -19,6 +19,10 @@
                         {{#has tag="#cover-object-light"}}
                             cover--object
                             cover--object--light
+                        {{/has}}
+                        {{#has tag="#cover-object-medium"}}
+                            cover--object
+                            cover--object--medium
                         {{/has}}
                         {{#has tag="#cover-object-dark"}}
                             cover--object


### PR DESCRIPTION
Add `#cover` and `#cover-object-medium` tags to activate this feature.