### PR TITLE
Fix captions in posts caused by the randomly inserted `<p>` tag

### DIFF
--- a/assets/scss/styles/08-koenig/_card.scss
+++ b/assets/scss/styles/08-koenig/_card.scss
@@ -1,5 +1,7 @@
 // Basic styling for all Ghost content blocks.
 // Ghost docs: https://ghost.org/docs/themes/content/#figure-and-figcaption
+//
+// 1. Get rid of the extra paragraph tag that is randomly inserted by Ghost to wrap the caption text.
 
 @use "../../tools/breakpoint";
 @use "../../tools/content-block";
@@ -15,6 +17,10 @@
     @include breakpoint.up(md) {
         margin-top: spacing.of(1);
     }
+}
+
+.kg-card figcaption > p {
+    display: contents; // 1.
 }
 
 .kg-embed-card {


### PR DESCRIPTION
Get rid of the extra paragraph tag that is randomly inserted by Ghost to wrap the caption text.

Before:

<img width="624" alt="obrazek" src="https://github.com/frontend-garden/frontend-garden-ghost-theme/assets/5614085/d1c33a9c-8efe-4621-8290-9a45cc3a5c17">

After:

<img width="660" alt="obrazek" src="https://github.com/frontend-garden/frontend-garden-ghost-theme/assets/5614085/71f4592d-15ae-4807-b617-c6ca97ce5c87">
